### PR TITLE
Remove deprecated Android package override

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNRatePackage.java
+++ b/android/src/main/java/com/reactlibrary/RNRatePackage.java
@@ -16,7 +16,7 @@ public class RNRatePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNRateModule(reactContext));
     }
 
-    @Override
+    // Deprecated < RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Issue https://github.com/KjellConnelly/react-native-rate/issues/1

Current version doesn't work with RN > 0.47 (on Android)