### PR TITLE
Add homepage to podspec file to fix error during pod install

### DIFF
--- a/ios/RNRate.podspec
+++ b/ios/RNRate.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNRate
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/KjellConnelly/react-native-rate"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Updated homepage in the podspec file due to error being thrown when running pod install