### PR TITLE
Callback refinement when in-app rating dialog fails and "openAppStoreIfInAppFails" is false

### DIFF
--- a/ios/RNRate.m
+++ b/ios/RNRate.m
@@ -51,8 +51,10 @@ RCT_EXPORT_METHOD(rate: (NSDictionary *)options : (RCTResponseSenderBlock) callb
             } else {
                 if (openAppStoreIfInAppFails) {
                   [self openAppStoreAndRate:url];
+                  callback(@[[NSNumber numberWithBool:true]]);
+                } else {
+                  callback(@[[NSNumber numberWithBool:false]]);
                 }
-                callback(@[[NSNumber numberWithBool:true]]);
             }
         }
     });


### PR DESCRIPTION
I ran into this use-case where I'm trying to show the in-app rating dialog, and I also set "openAppStoreIfInAppFails" to FALSE.

In this case, if the in-app rating dialog fails, nothing will happen, so it would seem to make sense that the callback returns false in this case, as the user is NOT taken to the app store.