### PR TITLE
Remove duplicate identifier in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ declare module 'react-native-rate' {
 		openAppStoreIfInAppFails?: boolean,
 		inAppDelay?: number,
 		fallbackPlatformURL?: string,
-		openAppStoreIfInAppFails?: boolean,
 	}
 
 	export enum AndroidMarket {


### PR DESCRIPTION
`openAppStoreIfInAppFails` is declared twice in index.d.ts