### PR TITLE
Clarify iOS installation in README to avoid errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Apple App Store | Google Play | Amazon | Other Android Markets | All Others
 ### Manual installation
 #### iOS
 
+##### Without CocoaPods
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-rate` and add `RNRate.xcodeproj`
 3. In XCode, in the project navigator, select your project. Add `libRNRate.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 
-#### Using CocoaPods
+##### Using CocoaPods
 
 Add the following to your `Podfile` (and run `pod install`):
 ```


### PR DESCRIPTION
The iOS install instructions were not really clear and one could easily read it as you have to do the `iOS` section of the `Manual Installation`, as well as the `Using CocoaPods` section. Understanding it as: "Well, I'm using iOS, so gotta do that. Oh, and also, I'm using CocoaPods so I probably have to do that too to make it work". 
This way it's a clear if-else between using CocoaPods or not.