### PR TITLE
React-namespace must be checked first to avoid going for normal import

### DIFF
--- a/ios/RNRate.h
+++ b/ios/RNRate.h
@@ -1,11 +1,14 @@
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
+#if __has_include(<React/RCTBridgeModule.h>)
+ // React Native >= 0.40
+ #import <React/RCTBridgeModule.h>
+ #import <React/RCTConvert.h>
 #else
-#import <React/RCTBridgeModule.h>
-#import <React/RCTConvert.h>
+ // React Native <= 0.39
+ #import "RCTBridgeModule.h" 
+ #import "RCTConvert.h"
 #endif
+
 #import <UIKit/UIKit.h>
 #import <StoreKit/StoreKit.h>
 


### PR DESCRIPTION
 If you have dep loaded \#import "lib" would work, so it doesn't go to react-namespace which mean for react-native>0.39 it will fail. So, you have to check for namespace first.

This is related to this issue:
https://github.com/KjellConnelly/react-native-rate/issues/34