### PR TITLE
Support for RN 0.60+ autolink

### DIFF
--- a/RNRate.podspec
+++ b/RNRate.podspec
@@ -1,22 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "RNRate"
-  s.version      = "1.0.1"
-  s.summary      = "RNRate"
-  s.description  = "RNRate"
-  s.homepage     = "https://github.com/KjellConnelly/react-native-rate"
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.name         = 'RNRate'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.author       = { "author" => package['author']['name'] }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/KjellConnelly/react-native-rate.git", :branch => "master" }
-  s.source_files  = "*.{h,m}"
+  s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
 
 end
-
-  


### PR DESCRIPTION
Updated podspec file to support React Native 0.60+ autolink

This solves issue https://github.com/KjellConnelly/react-native-rate/issues/46