### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNRate.podspec
+++ b/RNRate.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
 end


### PR DESCRIPTION
The latest Xcode 12 fails to build when a module does not depend on `React-Core` directly. This change is necessary for all native modules on iOS. For details please see: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116