### PR TITLE
Always give callback a success boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,12 @@ export default class Rate {
       if (options.preferredAndroidMarket === AndroidMarket.Google) {
         if (options.preferInApp) {
           RNRate.rate(options, response=>{
-            if (!response && options.openAppStoreIfInAppFails) {
-              Rate.openURL(GooglePrefix + options.GooglePackageName, callback)
+            if (!response) {
+              if (options.openAppStoreIfInAppFails) {
+                Rate.openURL(GooglePrefix + options.GooglePackageName, callback)
+              } else {
+                callback(false)
+              }
             } else {
               callback(response)
             }


### PR DESCRIPTION
Ideally, I'd love to see https://github.com/KjellConnelly/react-native-rate/pull/74 land, for more detailed success/error reporting! Thanks to the author of that PR for putting it together.

But in the meantime, I noticed that our callback was receiving no `success` boolean in production, on Android. From tracing the code, this is the only case I could identify in which `callback` wouldn't get an arg (in JS or in native). We do currently have `openAppStoreIfInAppFails` set to `false`.

If there's another way to address, please let me know. This would be the only place we call `callback` with an explicit argument in JS rather than a value raised from native code, but I think it's worth it to make things clearer to calling code.