### PR TITLE
Replace maven with maven-publish to comply with new standard

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-rate",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "React Native Rate is a cross platform solution to getting users to easily rate your app.",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
Hi @KjellConnelly - I added a version bump in here but let me know if it doesn't follow your standard or if you do releases differently.

As developers start upgrading their Android Gradle Plugins, they will start running into this issue as "maven" as a repository is deprecated and replaced with "maven-publish." 