### PR TITLE
Add missing imports to fix `RCTConvert` build error

### DIFF
--- a/ios/RNRate.m
+++ b/ios/RNRate.m
@@ -1,4 +1,6 @@
 #import "RNRate.h"
+#import "RCTBridgeModule.h"
+#import "React/RCTConvert.h"
 
 @implementation RNRate
 RCT_EXPORT_MODULE();


### PR DESCRIPTION
Fixes #95 

Not sure if this is the proper solution but it fixed my issue.