### PR TITLE
quickfix clang module

### DIFF
--- a/ios/RNRate.h
+++ b/ios/RNRate.h
@@ -1,11 +1,6 @@
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
-#else
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
-#endif
 #import <UIKit/UIKit.h>
 #import <StoreKit/StoreKit.h>
 


### PR DESCRIPTION
This is the same issue than this repo https://github.com/LinusU/react-native-get-random-values/pull/33