### PR TITLE
Fix issues building with expo 44 and duplicate versions

### DIFF
--- a/ios/RNRate.h
+++ b/ios/RNRate.h
@@ -1,11 +1,16 @@
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
-#import <React/RCTConvert.h>
+#else // Compatibility for RN version < 0.40
+#import "RCTBridgeModule.h"
 #endif
+
+#if __has_include(<React/RCTConvert.h>)
+#import <React/RCTConvert.h>
+#else // Compatibility for RN version < 0.40
+#import "RCTConvert.h"
+#endif
+
 #import <UIKit/UIKit.h>
 #import <StoreKit/StoreKit.h>
 


### PR DESCRIPTION
Addresses
- Declaration of 'RCTConvert' must be imported from module 'React.RCTConvert' before it is required
- Duplicate definitions

Fixes:
https://github.com/KjellConnelly/react-native-rate/issues/95
https://github.com/KjellConnelly/react-native-rate/issues/108
https://github.com/KjellConnelly/react-native-rate/issues/105