### PR TITLE
Replace JCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -66,7 +66,7 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
As JCenter has been past end of life for quite a while this PR changes build.gradle by replacing JCenter with mavenCentral. This solves #97.

Everything works the same after this change and this package stops relying on JCenter that has regular outages.

[JCenter end of life](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)