### PR TITLE
Update App Store URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { Platform, Linking, NativeModules } from 'react-native'
 
-const AppleNativePrefix = 'itms-apps://itunes.apple.com/app/id'
-const AppleWebPrefix = 'https://itunes.apple.com/app/id'
+const AppleNativePrefix = 'https://apps.apple.com/app/id'
+const AppleWebPrefix = 'https://apps.apple.com/app/id'
 const GooglePrefix = 'https://play.google.com/store/apps/details?id='
 const AmazonPrefix = 'amzn://apps/android?p='
 


### PR DESCRIPTION
The itunes url are deprecated. Updated to latest App Store urls.

"Previously, short links were available using the itunes.com URL. AppStore.com replaces itunes.com. iTunes.com links will continue to work but should be updated as soon as feasible."

Ref: https://developer.apple.com/library/archive/qa/qa1633/_index.html

Fixes issue: #100 