### PR TITLE
RN-0.73 change Android configs for RN 0.73 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
+    namespace = "com.reactnativerate"
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.reactnativerate">
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativerate">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
Starting from React Native v0.73 , all libraries will need to be updated with these two one-liners due to Android Gradle Plugin upgrade
https://github.com/react-native-community/discussions-and-proposals/issues/671

---

React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. This will require all the libraries to specify a namespace in their build.gradle file.

Details
I'd like to share some of the upcoming changes that will happen in 0.73, which is still a bit far, but we'd rather start earlier rather than later.

React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x, which brings a lot of improvements for Android apps but also a series of notable changes.

Most importantly:

App/Library Developers will now have to install and use [Java 17](https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp)
Library Developers will have to specify a namespace in [their build.gradle file](https://developer.android.com/build/releases/gradle-plugin#namespace-dsl).
Specifically, the last change is a breaking change and will make libraries that are not specifying a namespace incompatible with React Native 0.73 (your project won't build).

Support for namespace was added in AGP 7.3.x, which ships with React Native 0.71. Libraries that published a new version with a namespace declared for 0.71 or 0.72 don't need further update. So we invite library authors to do those changes as soon as possible so by the time 0.73 is out, most of the apps are adapted.

What you need to change
Library authors will have to update their `android/build.gradle` file as follows:

```diff
android {
+   namespace = "com.iterable.reactnative"
    ...
}
```
and remove the package definition from their `AndroidManifest.xml`:

```diff
<?xml version="1.0" encoding="utf-8"?>
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.iterable.reactnative">
+          >
...
</manifest>
```
Further reading
[Official Google documentation on namespaces is here](https://developer.android.com/build/configure-app-module#set-namespace).