### PR TITLE
Change iOS behavior to match android

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,14 +33,26 @@ export default class Rate {
   }
 
   static rate(inputOptions, callback = noop) {
-    const { RNRate } = NativeModules
-    const options = Rate.filterOptions(inputOptions)
-    if (Platform.OS === 'ios') {
-      options.AppleNativePrefix = AppleNativePrefix
-      RNRate.rate(options, (response, error) => {
-        callback(response, error)
-      })
-    } else if (Platform.OS === 'android') {
+    const { RNRate } = NativeModules;
+    const options = Rate.filterOptions(inputOptions);
+    if (Platform.OS === "ios") {
+      options.AppleNativePrefix = AppleNativePrefix;
+      if (options.preferInApp) {
+        RNRate.rate(options, (response, error) => {
+          if (!response) {
+            if (options.openAppStoreIfInAppFails) {
+              Rate.openURL(AppleNativePrefix + options.AppleAppID, callback);
+            } else {
+              callback(response, error);
+            }
+          } else {
+            callback(response, error);
+          }
+        });
+      } else {
+        Rate.openURL(AppleNativePrefix + options.AppleAppID, callback);
+      }
+    } else if (Platform.OS === "android") {
       if (options.preferredAndroidMarket === AndroidMarket.Google) {
         if (options.preferInApp) {
           RNRate.rate(options, (response, error)=>{


### PR DESCRIPTION
While trying to implement the package I noticed that the behavior for iOS and Android is different. 

Changes were made so that iOS also listens to the `preferInApp` flag and redirects to the App Store in case opening the pop up fails or the `preferInApp` flag is false.